### PR TITLE
Specifiable error types for Loadable

### DIFF
--- a/src/loadable.ts
+++ b/src/loadable.ts
@@ -21,7 +21,7 @@ const $NotLoaded = new class extends Loadable<any, any> {
   }
 }()
 
-export function NotLoaded<T> (): Loadable<T> {
+export function NotLoaded<T, E> (): Loadable<T, E> {
   return $NotLoaded
 }
 

--- a/src/resources/actions.ts
+++ b/src/resources/actions.ts
@@ -13,11 +13,11 @@ export const SetResourcesAction = Symbol('SetResourcesAction')
  * An action indicating the fact that the user wants to add resources to the
  * state.
  */
-export interface SetResourcesAction<T = {}> {
+export interface SetResourcesAction<T = {}, E = Error> {
   type: typeof SET_RESOURCES,
   payload: {
     resourceType: Type,
-    resources: Resources<T>
+    resources: Resources<T, E>
   }
 }
 
@@ -28,7 +28,7 @@ export interface SetResourcesAction<T = {}> {
  * @param resources The resources
  * @returns An `SetResourcesAction`
  */
-export function setResources<T = {}> (resourceType: Type, resources: Resources<T>): SetResourcesAction<T> {
+export function setResources<T = {}, E = Error> (resourceType: Type, resources: Resources<T, E>): SetResourcesAction<T, E> {
   return {
     type: SET_RESOURCES,
     payload: {
@@ -51,7 +51,7 @@ export const UnsetResourcesAction = Symbol('UnsetResourcesAction')
  * An action indicating the fact that the user wants to remove resources from
  * the state by their `id`s.
  */
-export interface UnsetResourcesAction<_T = {}> {
+export interface UnsetResourcesAction<_T = {}, _E = Error> {
   type: typeof UNSET_RESOURCES,
   payload: {
     resourceType: Type,
@@ -65,7 +65,7 @@ export interface UnsetResourcesAction<_T = {}> {
  * @param resourceIds The `id`s of the resources
  * @returns An `UnsetResourcesAction`
  */
-export function unsetResources<T = {}> (resourceType: Type, resourceIds: string[]): UnsetResourcesAction<T> {
+export function unsetResources<T = {}, E = Error> (resourceType: Type, resourceIds: string[]): UnsetResourcesAction<T, E> {
   return {
     type: UNSET_RESOURCES,
     payload: {
@@ -84,8 +84,8 @@ export function unsetResources<T = {}> (resourceType: Type, resourceIds: string[
  * @param resource The resource
  * @returns A `SetResourcesAction`
  */
-export function setResource<T = {}> (resourceType: Type, resourceId: string, resource: Loadable<T>) {
-  return setResources<T>(resourceType, { [resourceId]: resource })
+export function setResource<T = {}, E = Error> (resourceType: Type, resourceId: string, resource: Loadable<T, E>) {
+  return setResources<T, E>(resourceType, { [resourceId]: resource })
 }
 
 /**
@@ -94,11 +94,11 @@ export function setResource<T = {}> (resourceType: Type, resourceId: string, res
  * @param resourceId The `id`
  * @returns An `UnsetResourcesAction`
  */
-export function unsetResource<T = {}> (resourceType: Type, resourceId: string) {
-  return unsetResources<T>(resourceType, [resourceId])
+export function unsetResource<T = {}, E = Error> (resourceType: Type, resourceId: string) {
+  return unsetResources<T, E>(resourceType, [resourceId])
 }
 // #endregion
 
 export type ResourcesAction
-  = SetResourcesAction<any>
-  | UnsetResourcesAction<any>
+  = SetResourcesAction<any, any>
+  | UnsetResourcesAction<any, any>

--- a/src/resources/create-action-matchers.ts
+++ b/src/resources/create-action-matchers.ts
@@ -5,7 +5,7 @@ import { Type } from './state'
  * Creates action matchers for a specific resource.
  * @param resourceType The type of the resource
  */
-export function createActionMatchers<_T = {}> (resourceType: Type) {
+export function createActionMatchers<_T = {}, _E = Error> (resourceType: Type) {
   function _isSetResources (action: any): action is SetResourcesAction {
     return typeof action === 'object' && action.type === SET_RESOURCES
   }

--- a/src/resources/create-actions.ts
+++ b/src/resources/create-actions.ts
@@ -9,19 +9,19 @@ import { setResources, setResource, unsetResources, unsetResource, SetResourcesA
  * Creates action creators for the given resource type.
  * @param resourceType The type of the resource
  */
-export function createActions<T = {}> (resourceType: Type) {
+export function createActions<T = {}, E = Error> (resourceType: Type) {
   return {
-    setResource (resourceId: string, resource: Loadable<T>) {
-      return setResource(resourceType, resourceId, resource)
+    setResource (resourceId: string, resource: Loadable<T, E>) {
+      return setResource<T, E>(resourceType, resourceId, resource)
     },
-    setResources (resources: Resources<T>) {
-      return setResources(resourceType, resources)
+    setResources (resources: Resources<T, E>) {
+      return setResources<T, E>(resourceType, resources)
     },
     unsetResource (resourceId: string) {
-      return unsetResource(resourceType, resourceId)
+      return unsetResource<T, E>(resourceType, resourceId)
     },
     unsetResources (resourceIds: string[]) {
-      return unsetResources(resourceType, resourceIds)
+      return unsetResources<T, E>(resourceType, resourceIds)
     }
   }
 }

--- a/src/resources/create-selectors.ts
+++ b/src/resources/create-selectors.ts
@@ -7,16 +7,16 @@ import { getResource, getResources, getResourcesSafe, hasResource } from './sele
  * Creates selectors partially applied for a given type of resources.
  * @param resourceType A unique key representing the type of resources
  */
-export function createSelectors<T = {}> (resourceType: Type) {
+export function createSelectors<T = {}, E = Error> (resourceType: Type) {
   return {
-    getResource (state: State, id: string): Loadable<T> {
-      return getResource<T>(state, resourceType, id)
+    getResource (state: State, id: string): Loadable<T, E> {
+      return getResource<T, E>(state, resourceType, id)
     },
-    getResources (state: State, ids: string[]): Loadable<T>[] {
-      return getResources<T>(state, resourceType, ids)
+    getResources (state: State, ids: string[]): Loadable<T, E>[] {
+      return getResources<T, E>(state, resourceType, ids)
     },
-    getResourcesSafe (state: State, ids: string[]): Loadable<T>[] {
-      return getResourcesSafe<T>(state, resourceType, ids)
+    getResourcesSafe (state: State, ids: string[]): Loadable<T, E>[] {
+      return getResourcesSafe<T, E>(state, resourceType, ids)
     },
     hasResource (state: State, id: string): boolean {
       return hasResource(state, resourceType, id)

--- a/src/resources/selectors.ts
+++ b/src/resources/selectors.ts
@@ -10,7 +10,7 @@ import { State, Type, resourcesKey } from './state'
  * @param id The id of the resource
  * @returns An resource or `null`
  */
-export function getResource<T = {}> (state: State, resourceType: Type, id: string): Loadable<T> {
+export function getResource<T = {}, E = Error> (state: State, resourceType: Type, id: string): Loadable<T, E> {
   const resources = state[resourcesKey][resourceType]
 
   if (!resources) {
@@ -28,7 +28,7 @@ export function getResource<T = {}> (state: State, resourceType: Type, id: strin
  * @param ids An array of entity id
  * @returns An array of entities
  */
-export function getResources<T = {}> (state: State, resourceType: Type, ids: string[]): Loadable<T>[] {
+export function getResources<T = {}, E = Error> (state: State, resourceType: Type, ids: string[]): Loadable<T, E>[] {
   return ids.map(function (id) {
     return getResource(state, resourceType, id)
   })
@@ -43,11 +43,11 @@ export function getResources<T = {}> (state: State, resourceType: Type, ids: str
  * @param ids An array of resource id
  * @returns An array of resources
  */
-export function getResourcesSafe<T = {}> (state: State, resourceType: Type, ids: string[]): Loadable<T>[] {
+export function getResourcesSafe<T = {}, E = Error> (state: State, resourceType: Type, ids: string[]): Loadable<T, E>[] {
   console.warn(`'${getResourcesSafe.name}/${getResourcesSafe.length}' is deprecated`)
 
-  return ids.reduce<Loadable<T>[]>(function (resources, id) {
-    const resource = getResource(state, resourceType, id)
+  return ids.reduce<Loadable<T, E>[]>(function (resources, id) {
+    const resource = getResource<T, E>(state, resourceType, id)
 
     if (resource) {
       resources.push(resource)

--- a/src/resources/state.ts
+++ b/src/resources/state.ts
@@ -18,14 +18,14 @@ export type State = {
  * The structure of the state associated with the reducer.
  */
 export type ResourcesState = {
-  [type: string]: Resources<any>
+  [type: string]: Resources<any, any>
 }
 
 /**
  * The map of resources.
  */
-export type Resources<T = {}> = {
-  [entityId: string]: Loadable<T>
+export type Resources<T = {}, E = Error> = {
+  [entityId: string]: Loadable<T, E>
 }
 
 /**


### PR DESCRIPTION
`Loadable` now has a second type parameter defaulting to `Error` by
default in order to specify the `Failed` variant's error.